### PR TITLE
Exclude c99ExtendedIdentifier from Linux

### DIFF
--- a/Sources/Quick/NSString+C99ExtendedIdentifier.swift
+++ b/Sources/Quick/NSString+C99ExtendedIdentifier.swift
@@ -1,11 +1,4 @@
-//
-//  NSString+C99ExtendedIdentifier.swift
-//  Quick
-//
-//  Created by Alex Manzella on 06/12/16.
-//  Copyright © 2016 Brian Ivan Gesiak. All rights reserved.
-//
-
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
 import Foundation
 
 public extension NSString {
@@ -38,3 +31,4 @@ public extension NSString {
         return result.characters.count == 0 ? "_" : result
     }
 }
+#endif

--- a/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
+++ b/Tests/QuickTests/QuickTests/FunctionalTests/BundleModuleNameTests.swift
@@ -1,3 +1,4 @@
+#if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
 import XCTest
 @testable import Quick
 import Nimble
@@ -24,3 +25,4 @@ class BundleModuleNameSpecs: QuickSpec {
         }
     }
 }
+#endif


### PR DESCRIPTION
since it's not needed
